### PR TITLE
[fix] 홈조회 시 cart_item_id -> cart_state로 변경하고 true/false 값으로 전달

### DIFF
--- a/src/models/item.js
+++ b/src/models/item.js
@@ -45,14 +45,14 @@ module.exports = {
   selectItems: async function (req) {
     var userId = Number(req.decoded);
     var sqlSelect = `SELECT i.folder_id, f.folder_name, i.item_id, i.item_img, i.item_name, i.item_price, i.item_url, i.item_memo, 
-      CAST(i.create_at AS CHAR(10)) create_at, n.item_notification_type, CAST(n.item_notification_date AS CHAR(16)) item_notification_date, c.item_id cart_item_id 
-      FROM items i LEFT OUTER JOIN notification n 
-      ON i.item_id = n.item_id  
-      LEFT OUTER JOIN (SELECT DISTINCT folder_id, folder_name FROM folders) f 
-      ON i.folder_id = f.folder_id 
-      LEFT OUTER JOIN cart c
-      on i.item_id = c.item_id 
-      WHERE i.user_id = ? ORDER BY i.create_at DESC;`;
+    CAST(i.create_at AS CHAR(10)) create_at, n.item_notification_type, CAST(n.item_notification_date AS CHAR(16)) item_notification_date, IF(c.item_id IS NULL, false, true) as cart_state
+    FROM items i LEFT OUTER JOIN notification n 
+    ON i.item_id = n.item_id  
+    LEFT OUTER JOIN (SELECT DISTINCT folder_id, folder_name FROM folders) f 
+    ON i.folder_id = f.folder_id 
+    LEFT OUTER JOIN cart c
+    on i.item_id = c.item_id 
+    WHERE i.user_id = ? ORDER BY i.create_at DESC`;
     const connection = await pool.connection(async (conn) => conn);
     const [rows] = await connection.query(sqlSelect, [userId]);
     connection.release();


### PR DESCRIPTION
프론트 측 요청에 따라 해당 내용을 변경하였습니다.

슬랙에서 논의 시 성능 문제를 고려하여 `IF(c.item_id IS NULL, false, true)`를 사용하지 않으려고 했지만, 
홈 조회시에는 LEFT OUTER JOIN 하여 null 인 값들도 모두 데려와야 하기 때문에 사용하는 것으로 변경하였습니다. 