### PR TITLE
[mod] 알림 등록, 수정, 삭제 api 수정 + 코드 리포맷

### DIFF
--- a/src/config/firebaseClinet.js
+++ b/src/config/firebaseClinet.js
@@ -1,0 +1,21 @@
+const admin = require('firebase-admin');
+require('dotenv').config({ path: '../.env' });
+
+const firebaseConfig = {
+  type: process.env.FIREBASE_TYPE,
+  project_id: process.env.FIREBASE_PROJECT_ID,
+  private_key_id: process.env.FIREBASE_PRIVATE_KEY_ID,
+  private_key: process.env.FIREBASE_PRIVATE_KEY,
+  client_email: process.env.FIREBASE_CLIENT_EMAIL,
+  client_id: process.env.FIREBASE_CLIENT_ID,
+  auth_uri: process.env.FIREBASE_AUTH_URI,
+  token_uri: process.env.FIREBASE_TOKEN_URI,
+  auth_provider_x509_cert_url: process.env.FIREBASE_AUTH_PROVIDER_X509_CERT_URI,
+  client_x509_cert_url: process.env.FIREBASE_CLIENT_X509_CERT_URI,
+};
+
+const firebaseApp = admin.initializeApp({
+  credential: admin.credential.cert(firebaseConfig),
+});
+
+module.exports = { firebaseApp };

--- a/src/models/noti.js
+++ b/src/models/noti.js
@@ -1,22 +1,17 @@
-const pool = require("../config/db");
-const { NotFound } = require("../utils/errors");
-const { ErrorMessage } = require("../utils/response");
+const pool = require('../config/db');
+const { NotFound } = require('../utils/errors');
+const { ErrorMessage } = require('../utils/response');
 
 module.exports = {
   insertNoti: async function (req) {
-    var userId = Number(req.decoded);
-    var itemId = req.body.item_id;
-    var notiType = req.body.item_notification_type;
-    var notiDate = req.body.item_notification_date;
+    const userId = Number(req.decoded);
+    const itemId = req.body.item_id;
+    const notiType = req.body.item_notification_type;
+    const notiDate = req.body.item_notification_date;
 
-    var sqlInsert =
-      "INSERT INTO notification (user_id, item_id, item_notification_type, item_notification_date) VALUES(?,?,?,?)";
-    var params = [
-      userId,
-      itemId,
-      notiType,
-      notiDate,
-    ];
+    const sqlInsert =
+      'INSERT INTO notification (user_id, item_id, item_notification_type, item_notification_date) VALUES(?,?,?,?)';
+    const params = [userId, itemId, notiType, notiDate];
 
     const connection = await pool.connection(async (conn) => conn);
     await connection.beginTransaction();
@@ -32,8 +27,8 @@ module.exports = {
     return true;
   },
   selectNoti: async function (req) {
-    var userId = Number(req.decoded);
-    var sqlSelect = `SELECT i.item_id, i.item_img, i.item_name, n.item_notification_type, 
+    const userId = Number(req.decoded);
+    const sqlSelect = `SELECT i.item_id, i.item_img, i.item_name, n.item_notification_type, 
         CAST(n.item_notification_date AS CHAR(19)) item_notification_date, n.read_state 
         FROM notification n JOIN items i 
         ON n.item_id = i.item_id 
@@ -47,17 +42,18 @@ module.exports = {
     if (Array.isArray(rows) && !rows.length) {
       throw new NotFound(ErrorMessage.notiNotFound);
     }
-    return rows;
+
+    return Object.setPrototypeOf(rows, []);
   },
   updateNoti: async function (req) {
-    var userId = Number(req.decoded);
-    var itemId = Number(req.body.item_id);
-    var notiType = req.body.item_notification_type;
-    var notiDate = req.body.item_notification_date;
+    const userId = Number(req.decoded);
+    const itemId = Number(req.params.item_id);
+    const notiType = req.body.item_notification_type;
+    const notiDate = req.body.item_notification_date;
 
-    var sqlUpdate =
-      "UPDATE notification SET item_notification_type = ?, item_notification_date = ? WHERE user_id = ? AND item_id = ?";
-    var params = [notiType, notiDate, userId, itemId];
+    const sqlUpdate =
+      'UPDATE notification SET item_notification_type = ?, item_notification_date = ? WHERE user_id = ? AND item_id = ?';
+    const params = [notiType, notiDate, userId, itemId];
 
     const connection = await pool.connection(async (conn) => conn);
     await connection.beginTransaction();
@@ -73,11 +69,12 @@ module.exports = {
     return true;
   },
   updateNotiReadState: async function (req) {
-    var userId = Number(req.decoded);
-    var itemId = Number(req.body.item_id);
+    const userId = Number(req.decoded);
+    const itemId = Number(req.params.item_id);
 
-    var sqlUpdate = "UPDATE notification SET read_state = 1 WHERE user_id = ? AND item_id = ?";
-    var params = [userId, itemId];
+    const sqlUpdate =
+      'UPDATE notification SET read_state = 1 WHERE user_id = ? AND item_id = ?';
+    const params = [userId, itemId];
 
     const connection = await pool.connection(async (conn) => conn);
     await connection.beginTransaction();
@@ -93,11 +90,12 @@ module.exports = {
     return true;
   },
   deleteNoti: async function (req) {
-    var userId = Number(req.decoded);
-    var itemId = Number(req.body.item_id);
+    const userId = Number(req.decoded);
+    const itemId = Number(req.params.item_id);
 
-    var sqlDelete = "DELETE FROM notification WHERE user_id = ? AND item_id = ?";
-    var params = [userId, itemId];
+    const sqlDelete =
+      'DELETE FROM notification WHERE user_id = ? AND item_id = ?';
+    const params = [userId, itemId];
 
     const connection = await pool.connection(async (conn) => conn);
     await connection.beginTransaction();

--- a/src/routes/notiRoutes.js
+++ b/src/routes/notiRoutes.js
@@ -1,11 +1,16 @@
-const notiController = require("../controllers/notiController");
-const { verifyToken } = require("../middleware/auth");
-var router = require("express").Router();
+const notiController = require('../controllers/notiController');
+const { verifyToken } = require('../middleware/auth');
+const express = require('express');
+const router = new express.Router();
 
-router.post("/", verifyToken, notiController.insertNotiInfo);
-router.get("/", verifyToken, notiController.selectNotiInfo);
-router.put("/", verifyToken, notiController.updateNotiInfo);
-router.put("/readstate", verifyToken, notiController.updateNotiReadStateInfo);
-router.delete("/", verifyToken, notiController.deleteNotiInfo);
+router.post('/', verifyToken, notiController.insertNotiInfo);
+router.get('/', verifyToken, notiController.selectNotiInfo);
+router.put('/:item_id', verifyToken, notiController.updateNotiInfo);
+router.put(
+  '/:item_id/read-state',
+  verifyToken,
+  notiController.updateNotiReadStateInfo,
+);
+router.delete('/:item_id', verifyToken, notiController.deleteNotiInfo);
 
 module.exports = router;

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -1,12 +1,12 @@
 const Strings = {
-  /*알림*/
-  notiMessageTitle: "상품일정알림",
-  notiMessageDescription: "알림이 있습니다.",
-  
-  /*공통*/
-  true: "true"
+  /* 알림 */
+  notiMessageTitle: '상품일정알림',
+  notiMessageDescription: '알림이 있습니다.',
+
+  /* 공통 */
+  true: 'true',
 };
 
 module.exports = {
-  Strings
+  Strings,
 };


### PR DESCRIPTION
## What is this PR? 🔍
API 문서를 수정하면서 uri 에 item_id를 추가

## Key Changes 🔑
1. 등록, 수정, 읽음 상태 수정, 삭제 uri에 item_id를 추가하였습니다.
   - 등록의 경우, 해당 item의 noti를 설정한다고 생각되어 uri에 추가하였으나 피드백 받습니다.
   - 읽음 상태 수정의 경우, 해당 item의 read state를 변경한다고 생각되어 uri를 `/noti/{item_id}/read-state`로 변경하였습니다.
     - uri에는 camelCase는 지양하고(대소문자에 따라 다른 리소스로 인식하게 되기 때문), 언더바(_)보다 하이픈(-) 사용이 바람직하다고 하여 변경하였습니다. :memo:[참고-NHN REST API 문서](https://meetup.toast.com/posts/92)
2. firebase-admin을 설정하는 모듈은 noti가 아니라 config에서 해야 하는 작업이라 생각되어 별도로 뺐습니다.
   - postman 테스트 완료
3. 현재는 select 시 쿼리 결과를 바로 보내주는 문제를 새 객체로 변환하여 any 형태로 변경하여 전달합니다.
   - `noti.js`에 `selectNoti`함수에서 `return Object.setPrototypeOf(rows, []);` 부분
   - _프론트 측에 요청에 따라 전달 결과가 변경될 수 있는 부분 // TODO_
  
## To Reviewers 📢
- `params` 형태로 변경한 부분이 `noti.js`에 잘 반영되었는지 재검토 부탁드립니다.
