### PR TITLE
[mod] camelCase off 로 변경 + CI 개선

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
         "sourceType": "module"
     },
     "rules": {
-        "camelCase" : "warn",
+        "camelCase" : "off",
         "prettier/prettier": "error",
         "no-unused-vars": "warn",
         "no-bitwise": "off",

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -8,16 +8,26 @@ on:
     branches: 
       - main
       - dev
+      
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x] # 개발환경과 동일하게 맞춤
+        
     steps:
-      #CI
       # 브랜치에 checkout해 코드를 가져온다
-      - name: Checkout source code. # node 버전을 확인한다.
+      - name: Checkout source code. 
         uses: actions/checkout@v2
-      - name: Check Node v
-        run: node -v
+        
+      # node 설치 및 버전 확인한다.
+      - name: Node.js ${{ matrix.node-version }} install
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Check Npm -v
+        run: npm -v   
       # 캐시 작업 추가(이전에 dependency를 설치했다면 캐시를 이용하도록
 #       - name: Cache node modules
 #         id: node-cache
@@ -32,15 +42,32 @@ jobs:
 #             ${{ runner.os }}-build-
 #             ${{ runner.os }}-
       # 직업폴더를 설정 한 수 의존 파일을 설치한다.
-      - name: Install Dependencies
-        if: steps.node-cache.outputs.cache-hit != 'true'
-        working-directory: .
-        # --frozen-lockfile는 install 시 yarn.lock파일 생성 X, 업데이트 필요 시 실패
-        run: yarn install --frozen-lockfile
-      # Build한다
-      - name: Build # Fastify Build and Start
-        working-directory: .
-        run: yarn run build
+#       - name: Install Dependencies
+#         if: steps.node-cache.outputs.cache-hit != 'true'
+#         working-directory: .
+#         # --frozen-lockfile는 install 시 yarn.lock파일 생성 X, 업데이트 필요 시 실패
+#         run: yarn install --frozen-lockfile
+#       # Build한다
+#       - name: Build # Fastify Build and Start
+#         working-directory: .
+#         run: yarn run build
+
+        # npm ci를 통해 npm install 진행
+      - name: npm CI
+        run: npm ci
+        
+        #lint 통과 확인
+      - name: check ESLint
+        run: npm run lint
+        
+        # CI 통과 시 build하여 server.js 파일 생성
+      - name: run build (dev)
+        if: ${{ github.ref == 'refs/heads/dev' }} 
+        run: npm run build --if-present
+        
+      - name: run build (main)
+        if: ${{ github.ref == 'refs/heads/main' }} 
+        run: npm run build:production --if-present
         
       #CD
       # build 파일을 ec2에 올리기

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -61,14 +61,18 @@ jobs:
         run: npm run lint
         
         # CI 통과 시 build하여 server.js 파일 생성
-      - name: run build (dev)
+      - name: run build (main <- dev)
         if: ${{ github.ref == 'refs/heads/dev' }} 
-        run: npm run build --if-present
-        
-      - name: run build (main)
-        if: ${{ github.ref == 'refs/heads/main' }} 
         run: npm run build:production --if-present
         
+      - name: run build (dev <- *)
+        run: npm run build --if-present
+
+
+#   deploy:
+#     needs: build
+#     runs-on: ubuntu-latest
+#     steps:  
       #CD
       # build 파일을 ec2에 올리기
 #       - name: build file upload to ec2 


### PR DESCRIPTION
## What is this PR? 🔍
CI 내 step을 추가하여 개선하였습니다. (주석은 삭제할 예정)

## Key Changes 🔑
1. ESLint 설정 파일에서 camelCase를 off 로 바꾸었습니다. 변경 이유는 다음과 같습니다.
    - `~Controller.js`에서 제가 DB 처리하는 모듈은 구분을 쉽게 하기 위해 대문자로 시작하도록 (`User`) 하였는데 이 점에서 Lint가 규칙에 위배된다고 하여 warn이 아닌 error로 인식. (warn으로 줘도 error로 판단...)
    - 돌아가는데 문제는 없기 때문에 off로 변경.
2. CI node 버전 세팅을 개발 환경(local)과 동일하게 맞추었습니다.
3. CI 설치 후 node와 npm version을 확인하도록 하였습니다. (npm ci 명령의 경우, npm `5.7.1` 버전 이후부터 사용 가능)
   - [npm install -> npm ci로 변경한 이유](https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci)는 다음과 같습니다.
     - `npm ci`는 `npm install`과 커맨드가 유사하나, 2배 정도 빠르다고 npm blog에서 확인
     - `npm install`의 경우, package.json내의 dependencies와 devDependencies를 기준으로 패키지 파일을 설치
     - `npm ci`의 경우, package.json보다 package-lock.json이 우선. 
     - 만약, package.json내의 파일과 package-lock.json 내의 버전 등이 다르면, package-lock.json을 기준으로 package.json 파일을 수정, 명시되지 않은 부분에서는 오류를 발생하여 안정성 확보
4. eslint 를 빌드 전에 돌도록 추가하여 코드 검증 진행합니다.
5. 현재 서버 파일은 development 모드와 production 모드로 나눠서 동작 가능합니다.
   - 빌드도 다르게 동작 가능하도록 했기 때문에 git action에서 if로 action이 돌고 있는 브랜치가 뭔지에 따라 다르게 빌드하도록 추가
      - [참고 - github action 문법](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)

## To Reviewers 📢
- ci를 도입하여 action 속도가 증가하여 캐시 부분을 지울까 합니다..
   - 기존에 1분 n 초였는데 지금은 30~40초 대..