### PR TITLE
폴더 추가 시 추가된 폴더의 folder_id 전달 및 아이템 수정 hotfix

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -37,7 +37,7 @@ module.exports = {
               return res.status(StatusCode.CREATED).json({
                 success: true,
                 message: SuccessMessage.loginSuccessAfterSuccessSignUp,
-                token: token,
+                data: token,
               });
             });
           })(req, res);
@@ -74,7 +74,7 @@ module.exports = {
         return res.status(StatusCode.OK).json({
           success: true,
           message: SuccessMessage.loginSuccess,
-          token: token,
+          data: token,
         });
       });
     })(req, res);

--- a/src/controllers/folderController.js
+++ b/src/controllers/folderController.js
@@ -46,12 +46,11 @@ module.exports = {
         throw new BadRequest(ErrorMessage.BadRequestMeg);
       }
       await Folders.insertFolder(req).then((result) => {
-        if (result) {
-          res.status(StatusCode.CREATED).json({
-            success: true,
-            message: SuccessMessage.folderInsert,
-          });
-        }
+        res.status(StatusCode.CREATED).json({
+          success: true,
+          message: SuccessMessage.folderInsert,
+          data: result,
+        });
       });
     } catch (err) {
       next(err);

--- a/src/models/folder.js
+++ b/src/models/folder.js
@@ -75,7 +75,7 @@ module.exports = {
     if (rows.affectedRows < 1) {
       throw new NotFound(ErrorMessage.folderInsertError);
     }
-    return true;
+    return Number(rows.insertId);
   },
   updateFolder: async function (req) {
     const userId = Number(req.decoded);

--- a/src/models/item.js
+++ b/src/models/item.js
@@ -76,11 +76,13 @@ module.exports = {
       'UPDATE items SET item_name = ?, item_price = ?, item_url = ?, item_memo = ?';
     const params = [itemName, itemPrice, itemUrl, itemMemo];
 
-    if (itemImg != undefined) {
+    // 어아탬이미지 null 경우에만 동작
+    if (!itemImg) {
       sqlUpdate += ', item_img = ?';
       params.push(itemImg);
     }
-    if (folderId != undefined) {
+    // 폴더id가 있을 경우에만 동작
+    if (folderId) {
       sqlUpdate += ', folder_id = ?';
       params.push(folderId);
     }

--- a/src/models/item.js
+++ b/src/models/item.js
@@ -76,7 +76,7 @@ module.exports = {
       'UPDATE items SET item_name = ?, item_price = ?, item_url = ?, item_memo = ?';
     const params = [itemName, itemPrice, itemUrl, itemMemo];
 
-    // 어아탬이미지 null 경우에만 동작
+    // 아이템이미지 null 경우에만 동작
     if (!itemImg) {
       sqlUpdate += ', item_img = ?';
       params.push(itemImg);


### PR DESCRIPTION
## What is this PR? 🔍
프론트 측 요청으로 폴더 추가 시 추가된 폴더의 folder_id 전달하도록 변경하고 통일성을 유지시켰습니다.
아이템 수정 시 folder_id가 없어도 수정이 가능하도록 변경하였습니다.

## To Reviewers 📢
- response 형태(success, message, data) 통일하는게 안드 쪽에서 편리할 것 같아 `authController.js`에서 로그인 성공 시 token 보낼 때 token(기존)에 보내는 형태가 아닌 data(변경)에 보내도록 변경하였습니다.
```json
{
    "success": true,
    "message": "wishboard 앱 로그인 성공",
    "data": "eyJhbGciOiJIUzI1NiJ9.MTQ.A85-US7cfLNkEapk_88vjBo7KXVhc9JB8moMzrtdxkg"
}
```
