### PR TITLE
폴더 조회 쿼리 수정 + folder_thumbnail 사용하는 코드 삭제

### DIFF
--- a/src/controllers/folderController.js
+++ b/src/controllers/folderController.js
@@ -71,18 +71,6 @@ module.exports = {
       next(err);
     }
   },
-  updateFolderThumbnail: async function (req, res, next) {
-    await Folders.updateFolderThumbnail(req)
-      .then(() => {
-        res.status(StatusCode.OK).json({
-          success: true,
-          message: SuccessMessage.folderThumbnailUpdateError,
-        });
-      })
-      .catch((err) => {
-        next(err);
-      });
-  },
   deleteFolder: async function (req, res, next) {
     await Folders.deleteFolder(req)
       .then(() => {

--- a/src/controllers/folderController.js
+++ b/src/controllers/folderController.js
@@ -61,13 +61,11 @@ module.exports = {
       if (!req.body.folder_name) {
         throw new BadRequest(ErrorMessage.BadRequestMeg);
       }
-      await Folders.updateFolder(req).then((result) => {
-        if (result) {
-          res.status(StatusCode.OK).json({
-            success: true,
-            message: SuccessMessage.folderNameUpdate,
-          });
-        }
+      await Folders.updateFolder(req).then(() => {
+        res.status(StatusCode.OK).json({
+          success: true,
+          message: SuccessMessage.folderNameUpdate,
+        });
       });
     } catch (err) {
       next(err);

--- a/src/models/folder.js
+++ b/src/models/folder.js
@@ -65,11 +65,10 @@ module.exports = {
   },
   insertFolder: async function (req) {
     const folderName = req.body.folder_name;
-    const folderThumbnail = req.body.folder_thumbnail;
     const userId = Number(req.decoded);
 
-    const sqInsert = `INSERT INTO folders(folder_name, folder_thumbnail, user_id) VALUES (?, ?, ?)`;
-    const params = [folderName, folderThumbnail, userId];
+    const sqInsert = `INSERT INTO folders(folder_name, user_id) VALUES (?, ?)`;
+    const params = [folderName, userId];
 
     const connection = await pool.connection(async (conn) => conn);
     await connection.beginTransaction();
@@ -87,11 +86,10 @@ module.exports = {
   updateFolder: async function (req) {
     const userId = Number(req.decoded);
     const folderName = req.body.folder_name;
-    const folderThumbnail = req.body.folder_thumbnail;
     const folderId = Number(req.params.folder_id);
 
-    const sqlUpdate = `UPDATE folders SET folder_name = ?, folder_thumbnail = ? WHERE folder_id = ? and user_id = ?`;
-    const params = [folderName, folderThumbnail, folderId, userId];
+    const sqlUpdate = `UPDATE folders SET folder_name = ? WHERE folder_id = ? and user_id = ?`;
+    const params = [folderName, folderId, userId];
 
     const connection = await pool.connection(async (conn) => conn);
     await connection.beginTransaction();
@@ -103,26 +101,6 @@ module.exports = {
 
     if (rows.affectedRows < 1) {
       throw new NotFound(ErrorMessage.folderNameUpdateError);
-    }
-    return true;
-  },
-  updateFolderThumbnail: async function (req) {
-    const folderId = Number(req.params.folder_id);
-    const folderThumbnail = req.body.folder_thumbnail;
-
-    const sqlUpdate = `UPDATE folders SET folder_thumbnail = ? WHERE folder_id = ?`;
-    const params = [folderThumbnail, folderId];
-
-    const connection = await pool.connection(async (conn) => conn);
-    await connection.beginTransaction();
-    const [rows] = await connection
-      .query(sqlUpdate, params)
-      .then(await connection.commit())
-      .catch(await connection.rollback());
-    connection.release();
-
-    if (rows.affectedRows < 1) {
-      throw new NotFound(ErrorMessage.folderThumbnailUpdateError);
     }
     return true;
   },

--- a/src/routes/folderRoutes.js
+++ b/src/routes/folderRoutes.js
@@ -12,7 +12,6 @@ router.get(
 );
 router.post('/', verifyToken, folderController.insertFolder);
 router.put('/:folder_id', verifyToken, folderController.updateFolder);
-router.put('/image/:folder_id', folderController.updateFolderThumbnail);
 router.delete('/:folder_id', folderController.deleteFolder);
 
 module.exports = router;


### PR DESCRIPTION
## What is this PR? 🔍
폴더 조회 시 이미지를 현재 폴더에 들어간 아이템 중 가장 최근 아이템의 이미지를 전달하도록 변경하였습니다.
쿼리 형태를 변경하면서 더이상 사용하지 않는 folders 테이블의 folder_thumbnail 필드 관련 코드 삭제하였습니다.

## Key Changes 🔑
1. 폴더 조회 / 폴더 리스트 조회 시 가장 최근 아이템의 이미지를 전달하도록 변경
```sql
select f.user_id, f.folder_name, i.item_img folder_thumbnail, ifnull(ic.item_count, 0) item_count
from folders f left outer join **(select folder_id, item_img from items order by create_at desc limit 1)** i
on f.folder_id = i.folder_id 
left outer join (select folder_id, count(folder_id) item_count from items group by folder_id) ic
on f.folder_id = ic.folder_id
where f.user_id = 13 group by f.folder_id order by f.create_at desc;
```
- item 테이블에 대하여 각각 left outer join을 2번 사용한 이유는 각 쿼리별로 return되는 rows가 다르기 때문입니다. (notion 작성 참고)
- 해당 쿼리 내용은 테스트 시 `only_full_group_by`예외를 발생시켜 쿼리가 실행되지 않는 문제가 있어 우선 런타임 환경(mysql 재시작하기 전)에서 sql_mode를 해당 옵션을 삭제해주었습니다.
  - 런타임 환경에서만 삭제한 이유는 저 옵션이 있는 이유는 필요한 옵션이니 추가된 거라 판단되어 추후에 쿼리를 개선하려 합니다...

2. 변경된 return 형태
[폴더 조회]
```json
[
    {
        "user_id": 13,
        "folder_name": "호호수정",
        "folder_thumbnail": null,
        "item_count": 0
    },
    {
        "user_id": 13,
        "folder_name": "포스트만1수정2",
        "folder_thumbnail": "최근 등록된 아이템 이미지 값",
        "item_count": 1
    },
   ...
]
```
[폴더 리스트 조회]
```json
[
    {
        "folder_id": 51,
        "folder_name": "호호수정",
        "folder_thumbnail": null
    },
    {
        "folder_id": 41,
        "folder_name": "포스트만1수정2",
        "folder_thumbnail": "hi"
    },
   ...
]
```
## To Reviewers 📢
- `folder.js`, `folderController.js`, `folderRoutes.js`에서 폴더이미지(`folder_thumbnail`) 업데이트 하는 코드가 제대로 삭제되었는지 확인 부탁드립니다.
- `folder.js`에서 폴더 내 아이템 조회 시 (`selectFolderItems()`) 
   item 테이블의 `create_at`, noti 테이블의 `item_notification_type`, `CAST(item_notification_date AS CHAR(16))` 가 잘 추가 되었는지 확인부탁드립니다.