### PR TITLE
[feat] item 추가/수정/삭제 시 noti 추가/수정/삭제 되도록 구현

### DIFF
--- a/src/config/firebaseAdmin.js
+++ b/src/config/firebaseAdmin.js
@@ -14,8 +14,8 @@ const firebaseConfig = {
   client_x509_cert_url: process.env.FIREBASE_CLIENT_X509_CERT_URI,
 };
 
-const firebaseApp = admin.initializeApp({
+const firebaseAdmin = admin.initializeApp({
   credential: admin.credential.cert(firebaseConfig),
 });
 
-module.exports = { firebaseApp };
+module.exports = { firebaseAdmin };

--- a/src/controllers/notiController.js
+++ b/src/controllers/notiController.js
@@ -2,7 +2,7 @@ const Noti = require('../models/noti');
 const logger = require('../config/winston');
 const { BadRequest } = require('../utils/errors');
 const { Strings } = require('../utils/strings');
-const { firebaseApp } = require('../config/firebaseClinet');
+const { firebaseAdmin } = require('../config/firebaseAdmin');
 const {
   StatusCode,
   SuccessMessage,
@@ -13,7 +13,7 @@ const TAG = 'notiContoller ';
 
 async function sendNotification(message) {
   try {
-    const response = await firebaseApp.messaging().send(message);
+    const response = await firebaseAdmin.messaging().send(message);
     logger.info(`${SuccessMessage.notiFCMSend}: ${response}`);
     return true;
   } catch (err) {

--- a/src/controllers/notiController.js
+++ b/src/controllers/notiController.js
@@ -1,26 +1,8 @@
 const Noti = require('../models/noti');
 const logger = require('../config/winston');
-const { BadRequest } = require('../utils/errors');
-const { Strings } = require('../utils/strings');
-const { firebaseAdmin } = require('../config/firebaseAdmin');
-const {
-  StatusCode,
-  SuccessMessage,
-  ErrorMessage,
-} = require('../utils/response');
+const { StatusCode, SuccessMessage } = require('../utils/response');
 
 const TAG = 'notiContoller ';
-
-async function sendNotification(message) {
-  try {
-    const response = await firebaseAdmin.messaging().send(message);
-    logger.info(`${SuccessMessage.notiFCMSend}: ${response}`);
-    return true;
-  } catch (err) {
-    logger.error(TAG + err);
-    return false;
-  }
-}
 
 module.exports = {
   selectNotiInfo: async function (req, res, next) {
@@ -33,83 +15,12 @@ module.exports = {
         next(err);
       });
   },
-  insertNotiInfo: async function (req, res, next) {
-    try {
-      if (
-        !req.body.item_id ||
-        !req.body.item_notification_type ||
-        !req.body.item_notification_date
-      ) {
-        throw new BadRequest(ErrorMessage.BadRequestMeg);
-      }
-
-      const message = {
-        data: {
-          title: Strings.notiMessageTitle,
-          message: `${req.body.item_notification_type} ${Strings.notiMessageDescription}`,
-          isScheduled: true.toString(),
-          scheduledTime: req.body.item_notification_date,
-        },
-        token: req.body.fcm_token,
-      };
-
-      const isSuccessful = await sendNotification(message);
-      if (!isSuccessful) {
-        return res.status(StatusCode.BADREQUEST).json({
-          success: false,
-          message: ErrorMessage.notiFCMSendError,
-        });
-      }
-
-      const result = await Noti.insertNoti(req);
-      if (result) {
-        return res.status(StatusCode.CREATED).json({
-          success: true,
-          message: SuccessMessage.notiInsert,
-        });
-      }
-    } catch (err) {
-      next(err);
-    }
-  },
-  updateNotiInfo: async function (req, res, next) {
-    try {
-      if (
-        !req.body.item_notification_type ||
-        !req.body.item_notification_date
-      ) {
-        throw new BadRequest(ErrorMessage.BadRequestMeg);
-      }
-      await Noti.updateNoti(req).then((result) => {
-        if (result) {
-          res.status(StatusCode.OK).json({
-            success: true,
-            message: SuccessMessage.notiUpdate,
-          });
-        }
-      });
-    } catch (err) {
-      next(err);
-    }
-  },
   updateNotiReadStateInfo: async function (req, res, next) {
     await Noti.updateNotiReadState(req)
       .then(() => {
         res.status(StatusCode.OK).json({
           success: true,
           message: SuccessMessage.notiReadStateUpdate,
-        });
-      })
-      .catch((err) => {
-        next(err);
-      });
-  },
-  deleteNotiInfo: async function (req, res, next) {
-    await Noti.deleteNoti(req)
-      .then(() => {
-        res.status(StatusCode.OK).json({
-          success: true,
-          message: SuccessMessage.notiDelete,
         });
       })
       .catch((err) => {

--- a/src/models/item.js
+++ b/src/models/item.js
@@ -40,7 +40,7 @@ module.exports = {
     if (rows.affectedRows < 1) {
       throw new NotFound(ErrorMessage.itemInsertError);
     }
-    return true;
+    return Number(rows.insertId);
   },
   selectItems: async function (req) {
     const userId = Number(req.decoded);

--- a/src/routes/notiRoutes.js
+++ b/src/routes/notiRoutes.js
@@ -3,14 +3,11 @@ const { verifyToken } = require('../middleware/auth');
 const express = require('express');
 const router = new express.Router();
 
-router.post('/', verifyToken, notiController.insertNotiInfo);
 router.get('/', verifyToken, notiController.selectNotiInfo);
-router.put('/:item_id', verifyToken, notiController.updateNotiInfo);
 router.put(
   '/:item_id/read-state',
   verifyToken,
   notiController.updateNotiReadStateInfo,
 );
-router.delete('/:item_id', verifyToken, notiController.deleteNotiInfo);
 
 module.exports = router;

--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -8,10 +8,18 @@ const StatusCode = {
 };
 
 const SuccessMessage = {
-  /* 아이템*/
+  /* 아이템 및 알림*/
   itemInsert: '아이템 추가 성공',
   itemUpdate: '아이템 수정 성공',
-  itemDelete: '아이템 삭제 성공',
+  itemAndNotiDelete: '해당 아이템 및 알림 삭제 성공',
+
+  itemAndNotiInsert: '아이템 및 알림 추가 성공',
+  itemAndNotiUpdate: '아이템 및 알림 수정 성공',
+  itemUpdateAndNotiInsert: '아이템 수정 및 알림 추가 성공',
+  itemUpdateAndNotiDelete: '아이템 수정 및 알림 삭제 성공',
+
+  notiReadStateUpdate: '알림 읽음 상태 수정 성공',
+  notiFCMSend: '알림 전송 성공',
 
   /* 장바구니*/
   cartInsert: '장바구니 추가 성공',
@@ -23,13 +31,6 @@ const SuccessMessage = {
   folderNameUpdate: '폴더명 수정 성공',
   folderImageUpdate: '폴더이미지 수정 성공',
   folderDelete: '폴더 삭제 성공',
-
-  /* 알림*/
-  notiInsert: '알림 추가 성공',
-  notiUpdate: '알림 수정 성공',
-  notiReadStateUpdate: '알림 읽음 상태 수정 성공',
-  notiDelete: '알림 삭제 성공',
-  notiFCMSend: '알림 전송 성공',
 
   /* 사용자*/
   userInfoUpdate: '사용자 정보 수정 성공',
@@ -69,11 +70,10 @@ const ErrorMessage = {
 
   /* 알림*/
   notiNotFound: '알림 정보 없음',
-  notiUpdateError: '수정된 알림 없음',
+  notiTodayNotFound: '오늘 날짜 기준, 5분 전 알림 정보 없음',
   notiReadStateUpdateError: '수정된 알림 읽음 상태 없음',
-  notiInsertError: '추가된 알림 없음',
-  notiDeleteError: '삭제된 알림 없음',
   notiFCMSendError: '전송된 알림 없음. FCM 에러',
+  notiUpsertError: '추가되거나 수정된 알림 없음',
 
   /* 사용자*/
   userNotFound: '사용자 정보 없음',

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -2,6 +2,9 @@ const Strings = {
   /* 알림 */
   notiMessageTitle: '상품일정알림',
   notiMessageDescription: '알림이 있습니다.',
+
+  INSERT: 'INSERT',
+  UPSERT: 'UPSERT',
 };
 
 module.exports = {


### PR DESCRIPTION
## What is this PR? 🔍
item 추가/수정/삭제 시 noti가 추가/수정/삭제 되도록 변경 구현하였습니다. (postman 확인 완료)

## Key Changes 🔑
- 아이템 수정 시 `noti.js`에서 `upsertNoti`는 insert 에 on duplicate key update 키워드를 추가하여 해댕 PK값이 없다면 생성하고, 있다면 삭제 시 생성되도록 하였습니다. 
   - affectedRows가 1개면 insert, 2개면 delete 후 insert 하여 upsert 되었다고 상태를 표시하여 그에 따라 return value를 다르게 보내주도록 구현
 

## To Reviewers 📢
- noti에서는 개별적으로 추가/수정/삭제가 안된다고 하여(아이템을 통해 추가/수정/삭제) `notiRoutes.js`와 `notiController.js`에서 삭제하였습니다. 확인 부탁드립니다. 
