### PR TITLE
[mod] 사용자 정보 수정 api 케이스별로 수정 가능하도록 변경

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -21,19 +21,37 @@ module.exports = {
   },
   updateUserInfo: async function (req, res, next) {
     try {
-      if (!req.body.nickname) {
+      if (!req.body.nickname && !req.body.profile_img) {
         throw new BadRequest(ErrorMessage.BadRequestMeg);
       }
 
       const isValidate = await User.validateNickname(req);
 
       if (!isValidate) {
-        await User.updateInfo(req).then(() => {
-          res.status(StatusCode.OK).json({
-            success: true,
-            message: SuccessMessage.userInfoUpdate,
+        if (req.body.nickname && !req.body.profile_img) {
+          await User.updateNickname(req).then(() => {
+            res.status(StatusCode.OK).json({
+              success: true,
+              message: SuccessMessage.userNickNameUpdate,
+            });
           });
-        });
+        } else if (req.body.nickname && req.body.profile_img) {
+          await User.updateInfo(req).then(() => {
+            res.status(StatusCode.OK).json({
+              success: true,
+              message: SuccessMessage.userInfoUpdate,
+            });
+          });
+        }
+      } else {
+        if (req.body.profile_img) {
+          await User.updateImage(req).then(() => {
+            res.status(StatusCode.OK).json({
+              success: true,
+              message: SuccessMessage.userProfileImgUpdate,
+            });
+          });
+        }
       }
     } catch (err) {
       next(err);

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -63,6 +63,9 @@ module.exports = {
     return true;
   },
   validateNickname: async function (req) {
+    if (!req.body.nickname) {
+      return true;
+    }
     const nickname = req.body.nickname;
 
     const sqlSelect = 'SELECT nickname FROM users WHERE nickname = ?';
@@ -77,20 +80,57 @@ module.exports = {
 
     return false;
   },
+  updateImage: async function (req) {
+    const userId = Number(req.decoded);
+    const profileImg = req.body.profile_img;
+
+    const sqlUpdate = 'UPDATE users SET profile_img = ? WHERE user_id = ?';
+    const params = [profileImg, userId];
+
+    console.log(sqlUpdate);
+    console.log(params);
+
+    const connection = await pool.connection(async (conn) => conn);
+    await connection.beginTransaction();
+    const [rows] = await connection
+      .query(sqlUpdate, params)
+      .then(await connection.commit())
+      .catch(await connection.rollback());
+    connection.release();
+
+    if (rows.affectedRows < 1) {
+      throw new NotFound(ErrorMessage.userProfileImgUpdateNotFound);
+    }
+    return true;
+  },
+  updateNickname: async function (req) {
+    const userId = Number(req.decoded);
+    const nickname = req.body.nickname;
+
+    const sqlUpdate = 'UPDATE users SET nickname = ? WHERE user_id = ?';
+    const params = [nickname, userId];
+
+    const connection = await pool.connection(async (conn) => conn);
+    await connection.beginTransaction();
+    const [rows] = await connection
+      .query(sqlUpdate, params)
+      .then(await connection.commit())
+      .catch(await connection.rollback());
+    connection.release();
+
+    if (rows.affectedRows < 1) {
+      throw new NotFound(ErrorMessage.userNickNameUpdateNotFound);
+    }
+    return true;
+  },
   updateInfo: async function (req) {
     const userId = Number(req.decoded);
     const nickname = req.body.nickname;
     const profileImg = req.body.profile_img;
 
-    let sqlUpdate = 'UPDATE users SET nickname = ?';
-    const params = [nickname];
-
-    if (profileImg) {
-      sqlUpdate += ' , profile_img = ?';
-      params.push(profileImg);
-    }
-    sqlUpdate += ' WHERE user_id = ?';
-    params.push(userId);
+    const sqlUpdate =
+      'UPDATE users SET nickname = ?, profile_img = ? WHERE user_id = ?';
+    const params = [nickname, profileImg, userId];
 
     const connection = await pool.connection(async (conn) => conn);
     await connection.beginTransaction();

--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -37,6 +37,8 @@ const SuccessMessage = {
 
   /* 사용자*/
   userInfoUpdate: '사용자 정보 수정 성공',
+  userNickNameUpdate: '사용자 닉네임 수정 성공',
+  userProfileImgUpdate: '사용자 프로필 이미지 수정 성공',
   userFcmTokenUpdate: '사용자 Fcm Token 수정 성공',
   userDelete: '사용자 삭제 성공',
   userPushStateUpdate: '사용자 푸쉬 알림 여부 수정 성공',
@@ -84,6 +86,8 @@ const ErrorMessage = {
   validateNickname: '이미 존재하는 닉네임',
   userNotFound: '사용자 정보 없음',
   userInfoUpdateNotFound: '수정된 사용자 정보 없음',
+  userNickNameUpdateNotFound: '수정된 사용자 닉네임 없음',
+  userProfileImgUpdateNotFound: '수정된 사용자 프로필 이미지 없음',
   userFcmTokenUpdateNotFound: '수정된 사용자 fcm token 없음',
   userDeleteError: '삭제된 사용자 없음',
   userPushStateUpdateNotFound: '수정된 사용자 푸쉬 알림 여부 없음',


### PR DESCRIPTION
## What is this PR? 🔍
프론트 측 요청에 따라 케이스별로 사용자 정보를 수정할 수 있도록 변경

## Key Changes 🔑
1. models에 쿼리 작성 부분에는 닉네임/이미지/둘다 수정으로 함수 작성
2. controller에서는 한 api로 받아온 값을 parameter에 따라 models 함수를 따로 따로 호출하도록 수정

## To Reviewers 📢
포스트만 테스트 완료 하였습니다.
- `userContoller.js`에서 `updateUserInfo()`에 케이스는 위에서부터 아래로 다음과 같습니다.
    - `if(!req.body.nickname && !req.body.profile_img)` : 모두 null인 경우 
    - `if (!isValidate) return true` -> 요청 parameter가 profile_img만 있는 경우, else로 넘어감
    - `if (!isValidate) return false` -> 요청 parameter에 nickname이 존재했으나 이미 있는 닉네임은 아님
        - `if (req.body.nickname && !req.body.profile_img)` : 닉네임만 수정
        - `else if (req.body.nickname && req.body.profile_img)` : 모두 수정