### PR TITLE
[feat] 비밀번호 잊어버릴 경우, 메일 인증을 통해 재로그인 구현

### DIFF
--- a/src/middleware/mailTransport.js
+++ b/src/middleware/mailTransport.js
@@ -1,10 +1,14 @@
 const nodemailer = require('nodemailer');
 require('dotenv').config({ path: '../.env' });
 
+// TODO SSL 인증서 설정 후 주석 삭제 지우고 보안 포트 설정하기
+
 const mailConfig = {
-  service: 'Naver',
+  service: 'naver',
   host: 'smtp.naver.com',
   port: 587,
+  // port: 465, // 보안 포트
+  // secure: true, // ture for port 465, false for other ports
   auth: {
     user: process.env.WISHBOARD_NAVER_ID,
     pass: process.env.WISHBOARD_NAVER_PW,

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -20,7 +20,21 @@ module.exports = {
       .then(await connection.commit())
       .catch(await connection.rollback());
     connection.release();
-    return rows;
+    return Object.setPrototypeOf(rows, []);
+  },
+  signIn: async function (req) {
+    const email = req.body.email;
+    const sqlSelect =
+      'SELECT user_id, email, push_state FROM users WHERE email = ?';
+    const connection = await pool.connection(async (conn) => conn);
+    const [rows] = await connection.query(sqlSelect, email);
+    connection.release();
+
+    if (rows.affectedRows < 1) {
+      throw new NotFound(ErrorMessage.unvalidateUser);
+    }
+
+    return Object.setPrototypeOf(rows, []);
   },
   validateEmail: async function (req) {
     const email = req.body.email;

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -4,6 +4,7 @@ const router = new express.Router();
 
 router.post('/signin', authController.signIn);
 router.post('/signup', authController.signUp);
-router.post('/mail', authController.sendMail);
+router.post('/password-mail', authController.sendMail);
+router.post('/re-signin', authController.restartSignIn);
 
 module.exports = router;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -6,7 +6,6 @@ const router = new express.Router();
 router.delete('/', verifyToken, userController.deleteUserOne);
 router.put('/', verifyToken, userController.updateUserInfo);
 router.put('/fcm', verifyToken, userController.updateUserFCMToken);
-router.put('/password', userController.updateUserPassword);
 router.get('/', verifyToken, userController.selectUserInfo);
 
 module.exports = router;

--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -47,7 +47,7 @@ const SuccessMessage = {
   loginSuccessAfterSuccessSignUp: 'wishboard 회원가입 후 로그인 성공',
   loginfailedAfterSuccessSignUp: 'wishboard 회원가입 성공 후 로그인 실패',
   loginSuccess: 'wishboard 앱 로그인 성공',
-  sendMailForDynamicLink: '비밀번호 찾기를 위한 동적링크 메일로 전송 성공',
+  sendMailForCertifiedNumber: '비밀번호 찾기를 위한 인증번호 메일 전송 성공',
 };
 
 const ErrorMessage = {
@@ -100,6 +100,7 @@ const ErrorMessage = {
   unvalidateToken: 'token이 유효하지 않음',
   requestTokenAgain: 'token 없음. 요청 token 확인',
   sendMailFailed: '새 비밀번호 지정을 위한 메일 전송 실패',
+  unvalidateNumberAndSendMail: '유효하지 않은 인증번호. 메일 재전송',
 
   /* 공통*/
   BadRequestMeg: '잘못된 요청',

--- a/src/utils/sendMailMessage.js
+++ b/src/utils/sendMailMessage.js
@@ -1,23 +1,36 @@
-require('dotenv').config({ path: '../.env' });
-
 const fromEmail = process.env.WISHBOARD_NAVER_ID;
-const links = process.env.FIREBASE_LINK_TO_ANDROID;
-
 const message = {
   from: `WishBoard ${fromEmail}`,
   to: '',
-  subject: '[WishBoard] 비밀번호 찾기를 위한 링크가 도착했습니다.',
-  html: `
-        <h3> 안녕하세요. Wishboard 입니다. </h3>
-        <h3> 아래 링크를 클릭하여 앱으로 돌아가 새 비밀번호로 재설정 해주세요. </h3>
-        <h3> 감사합니다. </h3>
-    `,
+  subject: '[Wishboard] 이메일 로그인을 위한 인증번호를 보내드려요.',
+  html: '',
+  certificationNumber: '',
 };
 
-function generateMessage(toEmail) {
+function generateMessage(toEmail, randomNumber) {
   message.to = toEmail;
-  message.html += `<a href="${links}"> ${links} </h3>`;
+  message.certificationNumber = randomNumber;
+  message.html = generateHTML(randomNumber);
   return message;
 }
 
-module.exports = { generateMessage };
+function generateHTML(randomNumber) {
+  return (
+    `
+    <p>로그인 화면에서 아래의 인증번호를 입력하고 로그인을 완료해주세요. 인증코드는 5분 동안 유효합니다.</p>
+    <br />
+    <h3>` +
+    randomNumber +
+    `</h3>
+    <br />
+    <p>혹시 요청하지 않은 인증 메일을 받으셨나요? 걱정하지 마세요. </p>
+    <p>고객님의 이메일 주소가 실수로 입력된 것일 수 있어요. 직접 요청한 인증 메일이 아닌 경우 무시해주세요.</p>
+    <br />
+    <p>멋진 하루 보내세요!</p>
+    <br />
+    <p>Wishboard 팀 드림</p>
+    `
+  );
+}
+
+module.exports = { generateMessage, generateHTML };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,9 +57,6 @@ module.exports = {
       'process.env.WISHBOARD_NAVER_PW': JSON.stringify(
         process.env.WISHBOARD_NAVER_PW,
       ),
-      'process.env.FIREBASE_LINK_TO_ANDROID': JSON.stringify(
-        process.env.FIREBASE_LINK_TO_ANDROID,
-      ),
     }),
   ],
   stats: {


### PR DESCRIPTION
## What is this PR? 🔍
비밀번호 잊어버릴 경우, 메일 인증을 통해 재로그인 구현하였습니다.

## Key Changes 🔑
0. local db에 다음 제약조건을 추가해주세요.
```sql
alter table users add unique uk_email(email);
```
1. `users.js`에 singin 함수를 추가하여 email이 존재하는 경우, email, push_state, user_id를 return 받아 jwt로 만들어 보내줍니다.
2. `authContorller.js`에 메일 전송하는 함수와 재로그인하는 함수 추가
    - 메일 전송의 경우, 재로그인 실패 시에도 사용하기 때문에 함수화 하여 작성

## To Reviewers 📢
- 코드가 ... 맘에 들진 않아 추후 리팩토링 할 예정입니다. (피드백 주시면 감사땡큐해피입니다.)
- 메일 요청 (body값 필수)
```
POST /auth/password-mail
body{
  "email":~
}
```
- 재로그인 진행 (body값 필수)
```
POST /auth/re-signin
body{
  "verify":~
  "email":~
}
```