### PR TITLE
[mod] 유저 검증을 별도의 api로 빼고, 회원 가입 시 검증 삭제

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -10,7 +10,8 @@ module.exports = {
 
     const hashPassword = bcrypt.hashSync(password, 10);
 
-    const sqlInsert = 'INSERT INTO users (email, password) VALUES (?, ?)';
+    const sqlInsert =
+      'INSERT IGNORE INTO users (email, password) VALUES (?, ?)';
     const params = [email, hashPassword];
 
     const connection = await pool.connection(async (conn) => conn);
@@ -20,6 +21,11 @@ module.exports = {
       .then(await connection.commit())
       .catch(await connection.rollback());
     connection.release();
+
+    if (rows.affectedRows < 1) {
+      throw new NotFound(ErrorMessage.validateEmail);
+    }
+
     return Object.setPrototypeOf(rows, []);
   },
   signIn: async function (req) {

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -4,6 +4,7 @@ const router = new express.Router();
 
 router.post('/signin', authController.signIn);
 router.post('/signup', authController.signUp);
+router.post('/check-email', authController.checkEmail);
 router.post('/password-mail', authController.sendMail);
 router.post('/re-signin', authController.restartSignIn);
 

--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -48,6 +48,7 @@ const SuccessMessage = {
   loginfailedAfterSuccessSignUp: 'wishboard 회원가입 성공 후 로그인 실패',
   loginSuccess: 'wishboard 앱 로그인 성공',
   sendMailForCertifiedNumber: '비밀번호 찾기를 위한 인증번호 메일 전송 성공',
+  unvalidateEmail: '회원가입이 가능한 이메일주소',
 };
 
 const ErrorMessage = {
@@ -94,13 +95,13 @@ const ErrorMessage = {
   userPasswordUpdateNotFound: '수정된 사용자 비밀번호 없음',
 
   signUpFailed: 'wishboard 앱 회원가입 실패',
-  validateEmail: '이미 존재하는 아이디',
+  validateEmail: '이미 존재하는 이메일 주소',
   unvalidateUser: '존재하지 않는 유저',
-  checkIDPasswordAgain: '아이디 혹은 비밀번호를 다시 확인',
+  checkIDPasswordAgain: '이메일 주소 혹은 비밀번호를 다시 확인',
   unvalidateToken: 'token이 유효하지 않음',
   requestTokenAgain: 'token 없음. 요청 token 확인',
   sendMailFailed: '새 비밀번호 지정을 위한 메일 전송 실패',
-  unvalidateNumber: '유효하지 않은 인증번호.',
+  unvalidateVerificationCode: '유효하지 않은 인증번호.',
 
   /* 공통*/
   BadRequestMeg: '잘못된 요청',


### PR DESCRIPTION
## What is this PR? 🔍
프론트 측 요청에 따라 유저 검증을 별도의 api로 빼고, 회원 가입 시 검증 수행부를 삭제
- 유저 검증 api
```
POST /auth/check-email
body{
   "email": ~
}
```

## Key Changes 🔑
1. 회원가입 시 유저 검증하는 api를 따로 구분
   - 구분하면서 이미 존재하는 값인 경우 다음과 같은 에러가 발생하여 쿼리문에 'IGNORE'를 추가하고, query 수행 결과가 0이면 insert가 안되었다고 보아 이미 존재하는 이메일이라는 예외를 발생시키도록 하였습니다. 
   (이부분은 안드에서 별도 예외처리를 해주겠지만 혹시 몰라 추가한 부분)
   ```
   (node:34124) UnhandledPromiseRejectionWarning: Error: Duplicate entry 'qwer123sungshin.ac.kr' for key 'users.uk_email'
   ```
2. 비밀번호 잊은 경우 이메일로 로그인 시 `verify` 변수명을 `isVerify`로 수정