### PR TITLE
[fix] itemNotiType 못가져오는 버그 수정

### DIFF
--- a/src/utils/notiPushMessage.js
+++ b/src/utils/notiPushMessage.js
@@ -15,14 +15,14 @@ const message = {
 };
 
 function dataMessage(itemNotiType, itemId, deviceFcmToken) {
-  message.notification.body = `${NotiType.itemNotiType} ${Strings.notiMessageDescription}`;
+  message.notification.body = `${NotiType[itemNotiType]} ${Strings.notiMessageDescription}`;
   message.data.itemId = String(itemId);
   message.token = deviceFcmToken;
   return message;
 }
 
 function dataMessageWithCount(itemNotiType, itemId, notiCount, deviceFcmToken) {
-  message.notification.body = `${NotiType.itemNotiType} 알림 외 ${notiCount}개의 ${Strings.notiMessageDescription}`;
+  message.notification.body = `${NotiType[itemNotiType]} 알림 외 ${notiCount}개의 ${Strings.notiMessageDescription}`;
   message.data.itemId = String(itemId);
   message.token = deviceFcmToken;
   return message;


### PR DESCRIPTION
## What is this PR? 🔍
현재 안드로이드 테스트 중에 있는데 해당 부분에서 itemNotiType을 못읽어와 다음과 같이 접근 형태를 변경하였음
```
Cannot read properties of undefined (reading 'itemNotiType')
```
