### PR TITLE
[fix] itemNotiType 못가져오는 버그 수정

### DIFF
--- a/src/utils/notiPushMessage.js
+++ b/src/utils/notiPushMessage.js
@@ -15,14 +15,14 @@ const message = {
 };
 
 function dataMessage(itemNotiType, itemId, deviceFcmToken) {
-  message.notification.body = `${NotiType.itemNotiType} ${Strings.notiMessageDescription}`;
+  message.notification.body = `${NotiType[itemNotiType]} ${Strings.notiMessageDescription}`;
   message.data.itemId = String(itemId);
   message.token = deviceFcmToken;
   return message;
 }
 
 function dataMessageWithCount(itemNotiType, itemId, notiCount, deviceFcmToken) {
-  message.notification.body = `${NotiType.itemNotiType} 알림 외 ${notiCount}개의 ${Strings.notiMessageDescription}`;
+  message.notification.body = `${NotiType[itemNotiType]} 알림 외 ${notiCount}개의 ${Strings.notiMessageDescription}`;
   message.data.itemId = String(itemId);
   message.token = deviceFcmToken;
   return message;

--- a/src/utils/notiType.js
+++ b/src/utils/notiType.js
@@ -1,4 +1,4 @@
-const notiType = {
+const NotiType = {
   RESTOCK: '재입고',
   OPEN_DAY: '오픈일',
   PREORDER_CLOSE: '프리오더 마감',
@@ -7,5 +7,5 @@ const notiType = {
 };
 
 module.exports = {
-  notiType,
+  NotiType,
 };


### PR DESCRIPTION
## What is this PR? 🔍
```
Cannot read properties of undefined (reading 'itemNotiType')
```

## Key Changes 🔑
1. enum으로 뺐던 notiType객체를 사용 시 notiType으로 해야하는데 NotiType으로 해서 못읽은 것올  파악
  - NotiType으로 수정

## To Reviewers 📢
- local에서 알림 가져오는 것을 확인
