### PR TITLE
[mod] 푸쉬알림서비스 토글과 스케줄러 실행 분리

### DIFF
--- a/src/controllers/notiController.js
+++ b/src/controllers/notiController.js
@@ -1,17 +1,5 @@
 const Noti = require('../models/noti');
-const User = require('../models/user');
-const logger = require('../config/winston');
-const {
-  StatusCode,
-  SuccessMessage,
-  ErrorMessage,
-} = require('../utils/response');
-const { BadRequest } = require('../utils/errors');
-const schedule = require('node-schedule');
-const { Strings } = require('../utils/strings');
-const { sendSchduledService } = require('../middleware/notiScheduler');
-
-const task = schedule;
+const { StatusCode, SuccessMessage } = require('../utils/response');
 
 module.exports = {
   selectNotiInfo: async function (req, res, next) {
@@ -34,39 +22,5 @@ module.exports = {
       .catch((err) => {
         next(err);
       });
-  },
-  scheduleSettings: async function (req, res, next) {
-    try {
-      if (!req.query.push) {
-        throw new BadRequest(ErrorMessage.BadRequestMeg);
-      }
-      const pushService = req.query.push === 'true' ? true : false;
-
-      if (pushService) {
-        await User.updatePushState(req, pushService).then(() => {
-          logger.info(Strings.pushNotiSchedulerStart);
-          task.scheduleJob('0/30 * * * *', function () {
-            sendSchduledService(req);
-          });
-          return res.status(StatusCode.OK).json({
-            success: true,
-            message: SuccessMessage.notiPushServiceStart,
-          });
-        });
-      } else {
-        if (task != null) {
-          await User.updatePushState(req, pushService).then(() => {
-            logger.info(Strings.pushNotiSchedulerEnd);
-            task.gracefulShutdown();
-          });
-        }
-        return res.status(StatusCode.OK).json({
-          success: true,
-          message: SuccessMessage.notiPushServiceExit,
-        });
-      }
-    } catch (err) {
-      next(err);
-    }
   },
 };

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -93,4 +93,24 @@ module.exports = {
       next(err);
     }
   },
+  updateUserPushState: async function (req, res, next) {
+    const pushState = req.params.push === 'true' ? true : false;
+    await User.updatePushState(req, pushState)
+      .then(() => {
+        if (pushState) {
+          res.status(StatusCode.OK).json({
+            success: true,
+            message: SuccessMessage.notiPushServiceStart,
+          });
+        } else {
+          res.status(StatusCode.OK).json({
+            success: true,
+            message: SuccessMessage.notiPushServiceExit,
+          });
+        }
+      })
+      .catch((err) => {
+        next(err);
+      });
+  },
 };

--- a/src/routes/notiRoutes.js
+++ b/src/routes/notiRoutes.js
@@ -9,6 +9,4 @@ router.put(
   verifyToken,
   notiController.updateNotiReadStateInfo,
 );
-router.get('/schedule', verifyToken, notiController.scheduleSettings); // /noti/schedule?push=true/false
-
 module.exports = router;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -6,6 +6,11 @@ const router = new express.Router();
 router.put('/active', verifyToken, userController.unActiveUserOne);
 router.put('/', verifyToken, userController.updateUserInfo);
 router.put('/fcm', verifyToken, userController.updateUserFCMToken);
+router.put(
+  '/push-state/:push',
+  verifyToken,
+  userController.updateUserPushState,
+);
 router.get('/', verifyToken, userController.selectUserInfo);
 
 module.exports = router;

--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -23,6 +23,8 @@ const SuccessMessage = {
 
   notiPushServiceStart: '푸쉬 알림 서비스 시작',
   notiPushServiceExit: '푸쉬 알림 서비스 종료',
+  notiSchedulerStart: '푸쉬 알림 스케줄러 동작',
+  notiSchedulerExit: '푸쉬 알림 스케줄러 종료',
 
   /* 장바구니*/
   cartInsert: '장바구니 추가 성공',
@@ -77,12 +79,13 @@ const ErrorMessage = {
 
   /* 알림*/
   notiNotFound: '알림 정보 없음',
-  notiTodayNotFound: '오늘 날짜 기준, 예정된 알림 정보 없음',
+  notiTodayNotFound: '오늘 날짜 기준, 15분 후 예정된 알림 정보 없음',
   notiReadStateUpdateError: '수정된 알림 읽음 상태 없음',
   notiFCMSendError: 'FCM 토큰 에러. 토큰이 없거나 잘못된 경우',
   notiInsertError: '추가된 알림 없음',
   notiUpsertError: '추가되거나 수정된 알림 없음',
   notiSendFailed: 'Firebase FCM server로 전송 실패',
+  notiSchedulerERROR: '푸쉬 알림 스케줄러 동작 실패',
 
   /* 사용자*/
   validateNickname: '이미 존재하는 닉네임',


### PR DESCRIPTION
## What is this PR? 🔍
푸쉬 알림 동시에 이상하게 전송되는 빅 버그를 발견하여 회의를 통해 토글과 스케줄러 동작을 분리합니다.
스케줄러 부분을 수정 시 별도의 PR로 올릴 예정입니다.

현재 PR은 사용자탭에서 토글 버튼으로 푸쉬알림서비스를 on/off 하도록 변경합니다.

## Key Changes 🔑
1. `notiController` -> `userController` 로 이전
   - 기존 : 토글 변경과 동시에 스케줄러 동작이라 notiController에 코드 구현함
   - 변경 : 토글 변경 시 db에 값 변경이 일어나는 동작만 수행하므로 코드 위치 변경함. 이에 따라 response 메세지도 변경함
2. uri 변경
   - controller 변경에 따라 uri도 `/noti/schedule/push?=true/false`형태에서 `/user/push-state/{true/false}`형태로 변경

## To Reviewers 📢
- 안드는 uri 변경 반영 부탁드립니다!
