### PR TITLE
푸쉬 알림 서비스 멀티캐스트 방식으로 변경 및 토글 스위치와 분리

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -23,7 +23,6 @@ app.use(hpp());
 if (nodeEnv === 'production') {
   morganFormat = 'combined'; // Apache 표준
 } else {
-  // app.disable('x-powered-by'); // 서버 관련 소프트웨어 정보 disable 하도록 설정
   morganFormat = 'dev';
 }
 app.use(morgan(morganFormat, { stream: logger.stream }));

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,8 @@ require('dotenv').config({ path: '../.env' });
 const port = process.env.PORT;
 const nodeEnv = process.env.NODE_ENV;
 
+const schedule = require('node-schedule');
+const schduleService = require('./middleware/notiScheduler');
 const passport = require('passport');
 const passportConfig = require('./config/passport');
 
@@ -27,9 +29,18 @@ if (nodeEnv === 'production') {
 }
 app.use(morgan(morganFormat, { stream: logger.stream }));
 
-app.listen(port, () =>
-  logger.info(`Server start listening on port ${port} | ${nodeEnv}`),
-);
+app.listen(port, () => {
+  logger.info(`Server start listening on port ${port} | ${nodeEnv}`);
+  /** node 앱 실행과 동시에 푸쉬알림 스케줄러 실행 */
+  schedule.scheduleJob('0/30 * * * *', function () {
+    try {
+      schduleService.sendPushNotification();
+    } catch (err) {
+      schedule.gracefulShutdown();
+    }
+  });
+});
+
 app.get('/', (req, res) => res.send('Welcome to WishBoard!!'));
 app.set('port', port);
 

--- a/src/middleware/notiScheduler.js
+++ b/src/middleware/notiScheduler.js
@@ -1,20 +1,32 @@
 const { firebaseAdmin } = require('../config/firebaseAdmin');
 const Noti = require('../models/noti');
-const {
-  dataMessage,
-  dataMessageWithCount,
-} = require('../utils/notiPushMessage');
+const { message } = require('../utils/notiPushMessage');
 const logger = require('../config/winston');
 const { SuccessMessage, ErrorMessage } = require('../utils/response');
 
 async function sendFcmTokenToFirebase(message) {
   try {
-    const response = await firebaseAdmin.messaging().send(message);
-    logger.info(`${SuccessMessage.notiFCMSend}: ${response}`);
+    const response = await firebaseAdmin.messaging().sendMulticast(message); // 멀티캐스팅
+    logger.info(SuccessMessage.notiFCMSend);
+    logger.info(response); //* 추후 삭제
+    // failureCount 존재 시 예외처리
+    if (response.failureCount > 0) {
+      const failedTokens = [];
+      response.responses.forEach((resp, idx) => {
+        if (!resp.success) {
+          failedTokens.push(registrationTokens[idx]);
+        }
+      });
+      message.tokens = failedTokens; // 실패 토큰으로 메세지 재정의
+      // 실패 토큰에 한하여 재전송
+      const response = await firebaseAdmin.messaging().sendMulticast(message);
+      logger.info(`${SuccessMessage.notiFCMSend}: ${response}`);
+    }
     return true;
   } catch (e) {
     const firebaseError = { err: e };
     if (firebaseError.err.code == 'messaging/invalid-payload') {
+      console.log(e);
       logger.error(ErrorMessage.notiFCMSendError);
     } else {
       logger.error(e);
@@ -25,35 +37,17 @@ async function sendFcmTokenToFirebase(message) {
 
 module.exports = {
   /*
-   * @params: sendSchduledService()
-   * 1분마다 noti 테이블 조회하여 유저별로 5분 뒤에 알림을 보내야 할 데이터가 있는지 탐색
+   * @params: sendPushNotification()
+   * 30분마다 noti 테이블 조회하여 유저별로 알림을 보내야 할 데이터가 있는지 탐색
    * 데이터가 있을 경우 firebase에 fcm 토큰 전송
    */
-  sendSchduledService: async function (req, res) {
-    await Noti.selectNotiFrom30minAgo(req)
-      .then((notiData) => {
-        let message;
-        if (notiData.length === 1) {
-          message = dataMessage(
-            notiData[0].item_notification_type,
-            notiData[0].item_id,
-            notiData[0].fcm_token,
-          );
-        } else {
-          const notiCount = notiData.length;
-          message = dataMessageWithCount(
-            notiData[0].item_notification_type,
-            notiData[0].item_id,
-            notiCount,
-            notiData[0].fcm_token,
-          );
-        }
+  sendPushNotification: async function () {
+    await Noti.selectNotiFrom30minAgo()
+      .then((notiTokens) => {
+        // multicast 형식
+        message.tokens = notiTokens;
         sendFcmTokenToFirebase(message).catch(() => {
           logger.error(ErrorMessage.notiSendFailed);
-          return res.status(StatusCode.NOTFOUND).json({
-            success: false,
-            message: SuccessMessage.notiFCMSendError,
-          });
         });
       })
       .catch((err) => logger.info(err));

--- a/src/utils/notiPushMessage.js
+++ b/src/utils/notiPushMessage.js
@@ -1,31 +1,12 @@
 const { Strings } = require('./strings');
-const { NotiType } = require('./notiType');
-require('dotenv').config({ path: '../.env' });
 
+// multicast 방식
 const message = {
   notification: {
     title: Strings.notiMessageTitle,
-    body: '',
+    body: Strings.notiMessageDescription,
   },
-  data: {
-    itemId: '',
-    pushType: Strings.NOTI_SCREEN,
-  },
-  token: '',
+  tokens: '',
 };
 
-function dataMessage(itemNotiType, itemId, deviceFcmToken) {
-  message.notification.body = `${NotiType[itemNotiType]} ${Strings.notiMessageDescription}`;
-  message.data.itemId = String(itemId);
-  message.token = deviceFcmToken;
-  return message;
-}
-
-function dataMessageWithCount(itemNotiType, itemId, notiCount, deviceFcmToken) {
-  message.notification.body = `${NotiType[itemNotiType]} 알림 외 ${notiCount}개의 ${Strings.notiMessageDescription}`;
-  message.data.itemId = String(itemId);
-  message.token = deviceFcmToken;
-  return message;
-}
-
-module.exports = { dataMessage, dataMessageWithCount };
+module.exports = { message };

--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -79,7 +79,7 @@ const ErrorMessage = {
 
   /* 알림*/
   notiNotFound: '알림 정보 없음',
-  notiTodayNotFound: '오늘 날짜 기준, 15분 후 예정된 알림 정보 없음',
+  notiTodayNotFound: '오늘 날짜 기준, 30분 후 예정된 알림 정보 없음',
   notiReadStateUpdateError: '수정된 알림 읽음 상태 없음',
   notiFCMSendError: 'FCM 토큰 에러. 토큰이 없거나 잘못된 경우',
   notiInsertError: '추가된 알림 없음',

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -1,13 +1,15 @@
 const Strings = {
   /* 알림 */
   notiMessageTitle: '상품일정알림',
-  notiMessageDescription: '알림이 있습니다.',
+  notiMessageDescription:
+    '알림 설정한 상품이 있습니다. WishBoard에서 확인하세요!', // multicast 방식
 
   INSERT: 'INSERT',
   UPSERT: 'UPSERT',
 
-  NOTI_SCREEN: 'NOTI_SCREEN',
-  // EVENT_SCEREEN: 'EVENT_SCEREEN', //* 추후 전체 공지 알림 예정일 경우 사용
+  //* 추후 전체 공지 알림 예정일 경우 사용
+  // NOTI_SCREEN: 'NOTI_SCREEN',
+  // EVENT_SCEREEN: 'EVENT_SCEREEN',
 
   /* scheduler 시작/종료 */
   pushNotiSchedulerStart: '푸쉬 알림 스케줄러 시작',


### PR DESCRIPTION
## What is this PR? 🔍
여러 차례 테스트를 진행하면서 발견한 쿼리 에러 발견하여 해당 부분을 해결하고,
회의 때 논의한 내용을 바탕으로 토글 스위치와 푸쉬 알림 배치 동작을 분리하였습니다.

## Key Changes 🔑
1.쿼리 에러의 경우, where 조건에 `(n.item_notification_date) = DATE(NOW())` 를 추가하여 당일 날짜에 해당하는 결과 값만 가져오도록 수정
2. 멀티캐스트 방식으로 변경함으로써 쿼리 변경
  - 멀티캐스트 방식의 경우, 동일 메세지로 보내기 때문에 fcm_token만 필요합니다.
  - `distinct`를 사용하지 않고, `group by`를 사용하여 중복값을 제거한 fcm_token만 담도록 합니다.
  - fcm 동시테스트 중 실패한 경우에 대해 예외처리가 필요해보여 추가하였습니다. `logger.info(response);` 에는 응답 결과에 대한 중요 정보가 담겨 있어 추후 logger 에서 삭제할 예정입니다. 
3. `app.js`에 스케줄러 동작 코드를 추가하여 앱 실행과 동시에 실행되도록 변경
4. 
## To Reviewers 📢
- 우선 해당 방식으로 돌지만 ..... 슬랙에 말한대로 구독 방식으로 변경하려 합니다. 저희가 원하는 포맷으로 알림을 보내기 위함
- 드디어!! 푸쉬알림을 고쳤습니다. ㅎㅎ ... 같은 시간대에 동시 테스트를 진행해 준 영진에게 감사를... :heart:
