### PR TITLE
[fix] response 변수 중복 에러 해결

### DIFF
--- a/src/middleware/notiScheduler.js
+++ b/src/middleware/notiScheduler.js
@@ -19,9 +19,9 @@ async function sendFcmTokenToFirebase(message) {
         }
       });
       // 실패 토큰에 한하여 재전송
-      const response = await firebaseAdmin.messaging().sendAll(failedTokens);
-      logger.info(`${SuccessMessage.notiFCMSend}: ${response}`);
-      logger.info(response); //* 추후 삭제
+      const reResponse = await firebaseAdmin.messaging().sendAll(failedTokens);
+      logger.info(`${SuccessMessage.notiFCMSend}: ${reResponse}`);
+      logger.info(reResponse); //* 추후 삭제
     }
     return true;
   } catch (e) {
@@ -44,6 +44,7 @@ module.exports = {
   sendPushNotification: async function () {
     await Noti.selectNotiFrom30minAgo()
       .then((notiList) => {
+        console.log(notiList);
         const messages = [];
         Object.keys(notiList).forEach((token) => {
           const numOfNotiItems = notiList[token].length;
@@ -66,6 +67,7 @@ module.exports = {
           message.token = token;
           messages.push(message);
         });
+        console.log(messages);
         sendFcmTokenToFirebase(messages).catch(() => {
           logger.error(ErrorMessage.notiSendFailed);
         });


### PR DESCRIPTION
## What is this PR? 🔍
변수명 중복되어 실패 시 로그 확인이 정확히 불가하고 재전송이 안되는 점을 발견하여 수정합니다.

- 에러내용
```
 2022-03-27 22:30:00 [error] : Cannot access 'response' before initialization
```

