### PR TITLE
[mod] production 모드일 때만 빌드하도록 수정

### DIFF
--- a/.github/workflows/serverCICD.yml
+++ b/.github/workflows/serverCICD.yml
@@ -57,12 +57,7 @@ jobs:
 
           echo SLACK_API_TOKEN=${{ secrets.SLACK_API_TOKEN }} >> .env
         
-        # CI 통과 시 build하여 server.js 파일 생성
-      - name: Run build
-        run: |
-          echo NODE_ENV="development" >> .env
-          npm run build --if-present
-
+        # main 브랜치에 대한 PR만 빌드하여 S3에 업로드
       - name: Run build (main)
         if: ${{ github.base_ref == 'main' }} 
         run: |
@@ -70,10 +65,12 @@ jobs:
           npm run build:production --if-present 
 
       - name: Copy ecosystem.config.js
+        if: ${{ github.base_ref == 'main' }} 
         run: |
           cp ./ecosystem.config.js ./dist
 
       - name: Sharing files between jobs.
+        if: ${{ github.base_ref == 'main' }} 
         uses: actions/upload-artifact@v1
         with:
           name: dist
@@ -81,6 +78,7 @@ jobs:
 
   deploy:
     needs: build
+    if: ${{ github.base_ref == 'main' }} 
     runs-on: ubuntu-latest
     steps:  
       # build job에서 빌드한 파일(./dist/server.js) 가져오기


### PR DESCRIPTION
## What is this PR? 🔍
dev 모드일 경우에는 빌드 파일을 생성하지 않고 S3에 업로드 하지 않습니다.

production 모드의 경우에만 빌드 파일을 생성하여 S3에 업로드 하도록 합니다. 

## Key Changes 🔑
1. 빌드 2가지 경우 였는데 1가지만 냅둠. dev 브랜치 전인 경우 CI 돌고 lint까지만 적용
  - 빌드 파일은 생성하더라도 이제 S3에 업로드 되어선 안됨. 별도의 S3 공간을 만들어 저장해둘까 했는데 가난한 대학생이므로 dev모드일 땐 로컬에서 돌리는게 좋을 것 같음. (의견 받음)
2. 빌드파일은 main 에대한  PR 인 경우에만 진행하므로 이후 step과 deploy job에 대하여 if 문으로 걸어둠

## To Reviewers 📢 
 dev 브랜치에 대한 PR 이므로 건너 뛰는 것을 확인하였음.

<img width="1624" alt="스크린샷 2022-04-01 오후 2 58 55" src="https://user-images.githubusercontent.com/68772751/161204064-3ba5ca89-8632-4a27-b80c-873d73d91fce.png">

 