### PR TITLE
[mod] slack log-all 채널 삭제에 따라 커스텀 에러도 슬랙에 에러로 출력하도록 변경

### DIFF
--- a/src/middleware/handleError.js
+++ b/src/middleware/handleError.js
@@ -5,6 +5,10 @@ const Slack = require('../lib/slack');
 const handleErrors = (err, req, res, next) => {
   logger.error(err);
   if (err instanceof GeneralError) {
+    Slack.sendMessage({
+      color: Slack.Colors.info,
+      title: err,
+    });
     return res.status(err.getCode()).json({
       success: false,
       message: err.message,


### PR DESCRIPTION
## What is this PR? 🔍
 slack에서 release-log-all 채널 삭제에 따라 커스텀 에러도 슬랙에 에러로 출력하도록 변경
(잘못된 경로의 경우 알림 확인해서 어디서 요청오는지 직접 들어가서 확인하기 위함...)

pm2-slack 모듈을 삭제하고, 채널도 삭제했습니다 ㅎㅎ ... 