### PR TITLE
[hotfix] slack 알림 시 custom 에러의 경우 더 많은 내용을 볼 수 있도록 변경

### DIFF
--- a/src/middleware/handleError.js
+++ b/src/middleware/handleError.js
@@ -7,7 +7,10 @@ const handleErrors = (err, req, res, next) => {
   if (err instanceof GeneralError) {
     Slack.sendMessage({
       color: Slack.Colors.info,
-      title: `${err.getCode()} ${err.message}}`,
+      title: `${err.getCode()} ${err.message}`,
+      text: `[${req.method}] ${req.url} \`\`\`user-agent: ${req.header(
+        'user-agent',
+      )} \nip-adress: ${req.ip}\`\`\``,
     });
     return res.status(err.getCode()).json({
       success: false,


### PR DESCRIPTION
## What is this PR? 🔍
기존에 슬랙 알림 시 custom 에러 발생 시 볼 수 있는 정보를 추가하였습니다. 
<img width="1350" alt="스크린샷 2022-04-03 오후 6 27 29" src="https://user-images.githubusercontent.com/68772751/161421040-e5daace8-a954-4f4e-a6d0-c58600bb5e2f.png">

이를 추가하여 ec2에 접속하지 않더라도 어떤 요청을 누가 보냈는지 확인합니다.

## Key Changes 🔑
1. Slack에 알림 보낼 때 text 부분에 요청 url, user-agent, ip주소를 확인할 수 있도록 함 
