### PR TITLE
[add] 비밀번호 변경 api 구현

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -214,12 +214,14 @@ module.exports = {
     return true;
   },
   updatePasswrod: async function (req) {
+    const userId = Number(req.decoded);
     const email = req.body.email;
     const password = req.body.password;
     const hashPassword = bcrypt.hashSync(password, 10);
 
-    const sqlUpdate = 'UPDATE users SET password = ? WHERE email = ?';
-    const params = [hashPassword, email];
+    const sqlUpdate =
+      'UPDATE users SET password = ? WHERE email = ? AND user_id = ?';
+    const params = [hashPassword, email, userId];
 
     const connection = await pool.connection(async (conn) => conn);
     await connection.beginTransaction();
@@ -250,4 +252,5 @@ module.exports = {
     }
     return Object.setPrototypeOf(rows, []);
   },
+  unActiveUsersDelete: async function () {},
 };

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -6,6 +6,7 @@ const router = new express.Router();
 router.put('/active', verifyToken, userController.unActiveUserOne);
 router.put('/', verifyToken, userController.updateUserInfo);
 router.put('/fcm', verifyToken, userController.updateUserFCMToken);
+router.put('/re-passwd', verifyToken, userController.updateUserPassword);
 router.put(
   '/push-state/:push',
   verifyToken,


### PR DESCRIPTION
## What is this PR? 🔍
비밀번호 변경하는 api를 구현하였습니다. 
기존에 만들어두었더라구요 .. ! 추가로 몇가지만 변경하였습니다.
```
[request]
PUT /user/re-passwd
Authorization : Bearer Token
{
    "email":"q123@sungshin.ac.kr",
    "password":"qwer123!"
}

[response]
// 1. 200 OK
{
    "success": true,
    "message": "사용자 비밀번호 수정 성공"
}
// 2. 400 
{
  "success": false,
  "message": "잘못된 요청"
}
// 3. 401 
{
  "success": false,
  "message": "token 없음. 요청 token 확인"
}
// 4. 404
{
  "success": false,
  "message": "수정된 사용자 비밀번호 없음"
}
```
 
## Key Changes 🔑
1. update 쿼리에서 userId도 where 조건에서 추가 검증하도록 변경
2. uri 생성
   - `re-password`로 하려다가 뭔가 파악하기 쉬워서 남들이 쉽게 접근할까봐서리 ... `re-passwd` 했는데 어떠심이 .. ?

## To Reviewers 📢
- 제 생각에는 ui가 1)이메일 입력 후 -> 2)비밀번호 입력 한 다음에 비밀번호 수정하던 바이브였던 걸로 기억하는데 맞을까요 ? 
   - 그렇게 된다면  1)에선 이메일 검증 api 를 호출해주심 될 것 같은데, 제 쪽에서 이 부분을 연결해서 구현해야할지 고민이 되기도 하네요. 
   - ui에 따라 달라질 것 같아요!
      - 혹시 request parameter가 달라진다면 검토 부탁드립니다!
- 탈퇴 유저가 비밀번호를 수정하는 경우가 존재할까요?! 없을 것 같긴 한데 .. where 절에 `is_active = true`를 추가할지 고민되네요.
