### PR TITLE
[mod] artifact 저장소 만료로 요금 추가 발생 우려되어 job 구분 삭제

### DIFF
--- a/.github/workflows/serverCICD.yml
+++ b/.github/workflows/serverCICD.yml
@@ -12,7 +12,7 @@ on:
       - dev
       
 jobs:
-  build:
+  CICD:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -69,38 +69,43 @@ jobs:
         run: |
           cp ./ecosystem.config.js ./dist
 
-      - name: Sharing files between jobs.
-        if: ${{ github.base_ref == 'main' }} 
-        uses: actions/upload-artifact@v3
-        with:
-          name: dist
-          path: ./dist
-          retention-days: 3
-
-  deploy:
-    needs: build
-    if: ${{ github.base_ref == 'main' }} 
-    runs-on: ubuntu-latest
-    steps:  
-      # build job에서 빌드한 파일(./dist/server.js) 가져오기
-      - name: Sharing files between jobs.
-        uses: actions/download-artifact@v3
-        with:
-          name: dist
       # aws s3에 빌드 파일 저장
-      # ** 파일 이름이 동일해서 알아서 덮임
       - name : Build file upload to S3 and PM2 script
+        if: ${{ github.base_ref == 'main' }} 
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          mkdir dist
-          mv ecosystem.config.js server.js server.js.LICENSE.txt ./dist
-          ls -al
           aws s3 cp \
             --recursive \
             --region ap-northeast-2 \
             dist s3://wishboard-server-build
+
+  #** artifact 저장 기한을 정했지만 요금 제한으로 job간 이동 없이 바로 업로드 하도록 코드 수정
+  # deploy:
+  #   needs: build
+  #   if: ${{ github.base_ref == 'main' }} 
+  #   runs-on: ubuntu-latest
+  #   steps:  
+  #     # build job에서 빌드한 파일(./dist/server.js) 가져오기
+  #     - name: Sharing files between jobs.
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: dist
+  #     # aws s3에 빌드 파일 저장
+  #     # ** 파일 이름이 동일해서 알아서 덮임
+  #     - name : Build file upload to S3 and PM2 script
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #       run: |
+  #         mkdir dist
+  #         mv ecosystem.config.js server.js server.js.LICENSE.txt ./dist
+  #         ls -al
+  #         aws s3 cp \
+  #           --recursive \
+  #           --region ap-northeast-2 \
+  #           dist s3://wishboard-server-build
         # ** time out 문제로 우선 주석처리 후 직접 진행으로 변경    
       # # aws ec2에 접속
       # - name : Connect and Build file download to EC2 and PM2 script


### PR DESCRIPTION
## What is this PR? 🔍
눈물나게도 job 간의 share file 하는 artifact 의 저장 기한을 3일로 줄여 자동으로 삭제되도록 하였음에도 불구하고 ....
hyeeyoung 계정의 512mb(기본 지원)의 510mb를 사용하여 해당 부분을 삭제하였습니다.
<img width="611" alt="스크린샷 2022-04-08 오후 5 16 30" src="https://user-images.githubusercontent.com/68772751/162394834-0ac729ce-5a20-43ce-ab0d-a790195988ff.png">

## Key Changes 🔑
1. build -> deploy 으로 구성되는 ymal 파일을 CICD 라는 이름으로 job 이름을 변경하고 메인에서 빌드 파일 생성 시 바로 s3로 업로드 하도록 수정
