### PR TITLE
[fix] 파싱 결과가 200인 경우에만 통과하도록 변경 및 한글 사이트도 인식하도록 추가

### DIFF
--- a/src/lib/parser.js
+++ b/src/lib/parser.js
@@ -3,10 +3,18 @@ const cheerio = require('cheerio');
 const { NotFound } = require('../utils/errors');
 const { ErrorMessage } = require('../utils/response');
 
+const config = {
+  // headers: { 'User-Agent': 'Mozilla/5.0' },
+  validateStatus: function (status) {
+    return status >= 200 && status < 300;
+  },
+};
+
 const getHtml = async (url) => {
   try {
-    return await axios.get(url);
+    return await axios.get(encodeURI(url), config);
   } catch (err) {
+    console.log(err);
     throw new NotFound(ErrorMessage.itemParseFail);
   }
 };


### PR DESCRIPTION
## What is this PR? 🔍
#204 429 에러를 처리하려다가 200 에러만 파싱 성공으로 간주하고 그 외 에러는 모두 파싱 실패를 던지도록 수정

## Key Changes 🔑
1. 429 에러를 처리하려다가 200 에러만 파싱 성공으로 간주하고 그 외 에러는 모두 파싱 실패를 던지도록 수정
   - 429 에러는 요청을 많이 보내는 경우 발생하는 에러라 원인을 확실하게 아직 못찾았습니다 ㅠ
2. 자라의 경우, 우선 한글 문자가 URl에 포함되어 encodeURI()를 이용하여 해당 에러를 해결하였습니다만, 403 에러로 파싱 불가합니다 ..

