### PR TITLE
유저 탈퇴 api 추가

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -11,7 +11,6 @@ const nodeEnv = process.env.NODE_ENV;
 const passport = require('passport');
 const passportConfig = require('./config/passport');
 const schedule = require('node-schedule');
-const schduleService = require('./middleware/userScheduler');
 
 const handleErrors = require('./middleware/handleError');
 const { NotFound } = require('./utils/errors');
@@ -42,12 +41,6 @@ const server = app.listen(port, () => {
   /** 앱 시작 알림 */
   process.send('ready');
   logger.info(`[API Server] on port ${port} | ${nodeEnv}`);
-
-  /** 앱 시작과 동시에 사용자 탈퇴 스케줄러 실행 */
-  logger.info(SuccessMessage.userDeleteSchedulerStart);
-  schedule.scheduleJob('0 0 0 ? * MON *', function () {
-    schduleService.usersDelete();
-  });
 });
 
 process.on('SIGINT', function () {
@@ -55,8 +48,6 @@ process.on('SIGINT', function () {
   server.close(function () {
     /** 앱 및 스케줄러 종료*/
     logger.info('pm2 process closed');
-    schedule.gracefulShutdown().then(() => process.exit(0));
-    logger.info(SuccessMessage.userDeleteSchedulerExit);
   });
 });
 

--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -32,8 +32,6 @@ async function localVerify(email, password, done) {
         if (!rows[0]) return done(null, false);
 
         user = rows[0];
-        if (!user[0].is_active)
-          return done(null, false, ErrorMessage.unActiveUser);
 
         const checkPassword = bcrypt.compareSync(password, user[0].password);
         logger.info(TAG + checkPassword);

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -41,9 +41,6 @@ module.exports = {
             message: SuccessMessage.unValidateEmail,
           });
         } else {
-          if (!isValidate.isActive) {
-            return res.status(StatusCode.NOCONTENT).send();
-          }
           throw new Conflict(ErrorMessage.validateEmail);
         }
       });
@@ -89,28 +86,21 @@ module.exports = {
       if (!req.body.email || !req.body.password) {
         throw new BadRequest(ErrorMessage.BadRequestMeg);
       }
-      passport.authenticate(
-        'local',
-        { session: false },
-        (err, user, unActiveUser) => {
-          if (err || !user) {
-            logger.info(TAG + err || !user);
-            if (unActiveUser) {
-              return res.status(StatusCode.NOCONTENT).send();
-            }
-            return res.status(StatusCode.BADREQUEST).json({
-              success: false,
-              message: ErrorMessage.checkIDPasswordAgain,
-            });
-          }
-          const token = jwt.sign(user[0].user_id, process.env.JWT_SECRET_KEY);
-          return res.status(StatusCode.OK).json({
-            success: true,
-            message: SuccessMessage.loginSuccess,
-            data: { token },
+      passport.authenticate('local', { session: false }, (err, user) => {
+        if (err || !user) {
+          logger.info(TAG + err || !user);
+          return res.status(StatusCode.BADREQUEST).json({
+            success: false,
+            message: ErrorMessage.checkIDPasswordAgain,
           });
-        },
-      )(req, res, next);
+        }
+        const token = jwt.sign(user[0].user_id, process.env.JWT_SECRET_KEY);
+        return res.status(StatusCode.OK).json({
+          success: true,
+          message: SuccessMessage.loginSuccess,
+          data: { token },
+        });
+      })(req, res, next);
     } catch (err) {
       next(err);
     }
@@ -134,7 +124,6 @@ module.exports = {
         if (!isValidate.success) {
           throw new NotFound(ErrorMessage.unValidateUser);
         }
-        return res.status(StatusCode.NOCONTENT).send();
       }
     } catch (err) {
       next(err);

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -113,4 +113,16 @@ module.exports = {
         next(err);
       });
   },
+  deleteUser: async function (req, res, next) {
+    await User.deleteUser(req)
+      .then(() => {
+        res.status(StatusCode.OK).json({
+          success: true,
+          message: SuccessMessage.userDelete,
+        });
+      })
+      .catch((err) => {
+        next(err);
+      });
+  },
 };

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -238,4 +238,16 @@ module.exports = {
 
     return Number(rows.affectedRows);
   },
+  deleteUser: async function (req) {
+    const userId = Number(req.decoded);
+    const sqlDelete = 'DELETE FROM users WHERE user_id = ?';
+
+    const [rows] = await db.queryWithTransaction(sqlDelete, [userId]);
+
+    if (rows.affectedRows < 1) {
+      throw new NotFound(ErrorMessage.userDelete);
+    }
+
+    return true;
+  },
 };

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -19,5 +19,6 @@ router.put(
   userController.updateUserPushState,
 );
 router.get('/', verifyToken, userController.selectUserInfo);
+router.delete('/', verifyToken, userController.deleteUser);
 
 module.exports = router;


### PR DESCRIPTION
## What is this PR? 🔍

기존의 탈퇴 요청 시 is_active 상태를 false로 만들고, 스케줄러를 돌리면서 7일 후 탈퇴하는 로직이였는데
해당 로직을 탈퇴 요청 시 **즉시 삭제**로 변경합니다.

## Key Changes 🔑
1. app.js에서 탈퇴 스케줄러 삭제
  - 탈퇴 스케줄러 자체는 혹시 몰라 냅둡니다.
2. 로그인/회원가입 시 탈퇴 요청 유저지만, 삭제가 db에서 안된 경우 204를 보내주던 로직 삭제
3. 즉시 삭제(새 탈퇴 api) 추가

